### PR TITLE
Enhancement/handle null taskids

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubAdmin
 Title: Utilities for administering hubverse Hubs
-Version: 0.0.1
+Version: 0.1.0
 Authors@R: 
     c(person("Anna", "Krystalli", , "annakrystalli@googlemail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-2378-4915")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hubAdmin 0.1.0
+
+* Allow task ID `create_task_id()` arguments `required` and `optional` to both be set to `NULL`, facilitating the encoding of `NA` task IDs in modeling tasks where no value is expected for a given task ID.  
+
 # hubAdmin 0.0.1
 
 * Initial package release resulting from split of `hubUtils` package. See [`hubUtils` NEWS.md](https://github.com/Infectious-Disease-Modeling-Hubs/hubUtils/blob/main/NEWS.md) for details including previous release notes.

--- a/R/create_config.R
+++ b/R/create_config.R
@@ -10,7 +10,7 @@
 #' @seealso [create_rounds()]
 #' @details For more details consult
 #' the [documentation on `tasks.json` Hub config files](
-#' https://hubdocs.readthedocs.io/en/latest/format/hub-metadata.html#hub-model-task-metadata-tasks-json-file).
+#' https://hubdocs.readthedocs.io/en/latest/quickstart-hub-admin/tasks-config.html).
 #'
 #' @examples
 #' rounds <- create_rounds(

--- a/R/create_output_type.R
+++ b/R/create_output_type.R
@@ -10,7 +10,7 @@
 #' [create_output_type_pmf()], [create_output_type_sample()]
 #' @details For more details consult
 #' the [documentation on `tasks.json` Hub config files](
-#' https://hubdocs.readthedocs.io/en/latest/format/hub-metadata.html#hub-model-task-metadata-tasks-json-file).
+#' https://hubdocs.readthedocs.io/en/latest/quickstart-hub-admin/tasks-config.html).
 #' @examples
 #' create_output_type(
 #'   create_output_type_mean(

--- a/R/create_output_type_item.R
+++ b/R/create_output_type_item.R
@@ -13,7 +13,7 @@
 #'
 #' @details For more details consult
 #' the [documentation on `tasks.json` Hub config files](
-#' https://hubdocs.readthedocs.io/en/latest/format/hub-metadata.html#hub-model-task-metadata-tasks-json-file).
+#' https://hubdocs.readthedocs.io/en/latest/quickstart-hub-admin/tasks-config.html).
 #' @return a named list of class `output_type_item` representing a `mean` or
 #' `median` output type.
 #' @inheritParams create_task_id
@@ -156,7 +156,7 @@ create_output_type_point <- function(output_type = c("mean", "median"),
 #' @inheritParams create_output_type_mean
 #' @details For more details consult
 #' the [documentation on `tasks.json` Hub config files](
-#' https://hubdocs.readthedocs.io/en/latest/format/hub-metadata.html#hub-model-task-metadata-tasks-json-file).
+#' https://hubdocs.readthedocs.io/en/latest/quickstart-hub-admin/tasks-config.html).
 #'
 #' @return a named list of class `output_type_item` representing a `quantile`,
 #' `cdf`, `pmf` or `sample` output type.

--- a/R/create_round.R
+++ b/R/create_round.R
@@ -33,13 +33,13 @@
 #'  of file format in `admin.json`. For more details on whether this argument can
 #'  be used as well as available formats, please consult
 #' the [documentation on `tasks.json` Hub config files](
-#' https://hubdocs.readthedocs.io/en/latest/format/hub-metadata.html#hub-model-task-metadata-tasks-json-file).
+#' https://hubdocs.readthedocs.io/en/latest/quickstart-hub-admin/tasks-config.html).
 #' @return a named list of class `round`.
 #' @export
 #' @seealso [create_rounds()]
 #' @details For more details consult
 #' the [documentation on `tasks.json` Hub config files](
-#' https://hubdocs.readthedocs.io/en/latest/format/hub-metadata.html#hub-model-task-metadata-tasks-json-file).
+#' https://hubdocs.readthedocs.io/en/latest/quickstart-hub-admin/tasks-config.html).
 #' @examples
 #' model_tasks <- create_model_tasks(
 #'   create_model_task(

--- a/R/create_rounds.R
+++ b/R/create_rounds.R
@@ -8,7 +8,7 @@
 #' @seealso [create_round()]
 #' @details For more details consult
 #' the [documentation on `tasks.json` Hub config files](
-#' https://hubdocs.readthedocs.io/en/latest/format/hub-metadata.html#hub-model-task-metadata-tasks-json-file).
+#' https://hubdocs.readthedocs.io/en/latest/quickstart-hub-admin/tasks-config.html).
 #'
 #' @examples
 #' model_tasks <- create_model_tasks(

--- a/R/create_target_metadata.R
+++ b/R/create_target_metadata.R
@@ -8,7 +8,7 @@
 #' @seealso [create_target_metadata_item()]
 #' @details For more details consult
 #' the [documentation on `tasks.json` Hub config files](
-#' https://hubdocs.readthedocs.io/en/latest/format/hub-metadata.html#hub-model-task-metadata-tasks-json-file).
+#' https://hubdocs.readthedocs.io/en/latest/quickstart-hub-admin/tasks-config.html).
 #'
 #' @examples
 #' create_target_metadata(

--- a/R/create_target_metadata_item.R
+++ b/R/create_target_metadata_item.R
@@ -32,7 +32,7 @@
 #' @seealso [create_target_metadata()]
 #' @details For more details consult
 #' the [documentation on `tasks.json` Hub config files](
-#' https://hubdocs.readthedocs.io/en/latest/format/hub-metadata.html#hub-model-task-metadata-tasks-json-file).
+#' https://hubdocs.readthedocs.io/en/latest/quickstart-hub-admin/tasks-config.html).
 #' @return a named list of class `target_metadata_item`.
 #' @export
 #'

--- a/R/create_task_id.R
+++ b/R/create_task_id.R
@@ -32,7 +32,7 @@
 #'            row.names = NULL))
 #' ```
 #' Values across `required` and `optional` arguments must be unique. `required`
-#' and `optional` must be of the same type (unless `NULL`) and both cannot be `NULL`.
+#' and `optional` must be of the same type (unless `NULL`).
 #' Task_ids that represent dates must be supplied as character strings in ISO 8601
 #' date format (YYYY-MM-DD). If working with date objects, please convert to character
 #' (e.g. using `as.character()`) before supplying as arguments.
@@ -87,7 +87,6 @@ create_task_id <- function(name, required, optional,
     )
   }
 
-  check_prop_not_all_null(required, optional)
   check_prop_type_const(required, optional)
   check_prop_dups(required, optional)
 
@@ -187,7 +186,7 @@ check_prop_type_const <- function(required, optional) {
   ) %>%
     unique()
 
-  if (length(prop_types) != 1L && !"NULL" %in% prop_types) {
+  if (length(prop_types) > 1L && !"NULL" %in% prop_types) {
     cli::cli_abort(c(
       "x" = "Arguments {.arg required} and {.arg optional}
               must be of same type.",

--- a/R/create_task_id.R
+++ b/R/create_task_id.R
@@ -20,7 +20,7 @@
 #' @details `required` and `optional` vectors for standard task_ids defined in a Hub schema
 #' must match data types and formats specified in the schema. For more details consult
 #' the [documentation on `tasks.json` Hub config files](
-#' https://hubdocs.readthedocs.io/en/latest/format/hub-metadata.html#hub-model-task-metadata-tasks-json-file)
+#' https://hubdocs.readthedocs.io/en/latest/quickstart-hub-admin/tasks-config.html)
 #'
 #' JSON schema data type names differ to those in R. Use the following mappings to
 #' create vectors of appropriate data types which will correspond to correct JSON

--- a/R/create_task_ids.R
+++ b/R/create_task_ids.R
@@ -7,7 +7,7 @@
 #' @seealso [create_task_id()]
 #' @details For more details consult
 #' the [documentation on `tasks.json` Hub config files](
-#' https://hubdocs.readthedocs.io/en/latest/format/hub-metadata.html#hub-model-task-metadata-tasks-json-file).
+#' https://hubdocs.readthedocs.io/en/latest/quickstart-hub-admin/tasks-config.html).
 #'
 #' @examples
 #' create_task_ids(

--- a/man/create_config.Rd
+++ b/man/create_config.Rd
@@ -19,7 +19,7 @@ class \code{config}. This can be written out to a \code{tasks.json} file.
 }
 \details{
 For more details consult
-the \href{https://hubdocs.readthedocs.io/en/latest/format/hub-metadata.html#hub-model-task-metadata-tasks-json-file}{documentation on \code{tasks.json} Hub config files}.
+the \href{https://hubdocs.readthedocs.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
 }
 \examples{
 rounds <- create_rounds(

--- a/man/create_output_type.Rd
+++ b/man/create_output_type.Rd
@@ -18,7 +18,7 @@ Create an \code{output_type} class object.
 }
 \details{
 For more details consult
-the \href{https://hubdocs.readthedocs.io/en/latest/format/hub-metadata.html#hub-model-task-metadata-tasks-json-file}{documentation on \code{tasks.json} Hub config files}.
+the \href{https://hubdocs.readthedocs.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
 }
 \examples{
 create_output_type(

--- a/man/create_output_type_mean.Rd
+++ b/man/create_output_type_mean.Rd
@@ -57,7 +57,7 @@ or appended to \code{tasks.json} Hub config files.
 }
 \details{
 For more details consult
-the \href{https://hubdocs.readthedocs.io/en/latest/format/hub-metadata.html#hub-model-task-metadata-tasks-json-file}{documentation on \code{tasks.json} Hub config files}.
+the \href{https://hubdocs.readthedocs.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
 }
 \section{Functions}{
 \itemize{

--- a/man/create_output_type_quantile.Rd
+++ b/man/create_output_type_quantile.Rd
@@ -84,7 +84,7 @@ or appended to \code{tasks.json} Hub config files.
 }
 \details{
 For more details consult
-the \href{https://hubdocs.readthedocs.io/en/latest/format/hub-metadata.html#hub-model-task-metadata-tasks-json-file}{documentation on \code{tasks.json} Hub config files}.
+the \href{https://hubdocs.readthedocs.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
 }
 \section{Functions}{
 \itemize{

--- a/man/create_round.Rd
+++ b/man/create_round.Rd
@@ -54,7 +54,7 @@ This option in only available for some versions of the schema and is ignored if
 not allowed in the version of the schema used. It also overrides any specification
 of file format in \code{admin.json}. For more details on whether this argument can
 be used as well as available formats, please consult
-the \href{https://hubdocs.readthedocs.io/en/latest/format/hub-metadata.html#hub-model-task-metadata-tasks-json-file}{documentation on \code{tasks.json} Hub config files}.}
+the \href{https://hubdocs.readthedocs.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.}
 }
 \value{
 a named list of class \code{round}.
@@ -68,7 +68,7 @@ appended to \code{tasks.json} Hub config files.
 }
 \details{
 For more details consult
-the \href{https://hubdocs.readthedocs.io/en/latest/format/hub-metadata.html#hub-model-task-metadata-tasks-json-file}{documentation on \code{tasks.json} Hub config files}.
+the \href{https://hubdocs.readthedocs.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
 }
 \examples{
 model_tasks <- create_model_tasks(

--- a/man/create_rounds.Rd
+++ b/man/create_rounds.Rd
@@ -18,7 +18,7 @@ Create a \code{rounds} class object.
 }
 \details{
 For more details consult
-the \href{https://hubdocs.readthedocs.io/en/latest/format/hub-metadata.html#hub-model-task-metadata-tasks-json-file}{documentation on \code{tasks.json} Hub config files}.
+the \href{https://hubdocs.readthedocs.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
 }
 \examples{
 model_tasks <- create_model_tasks(

--- a/man/create_target_metadata.Rd
+++ b/man/create_target_metadata.Rd
@@ -18,7 +18,7 @@ Create a \code{target_metadata} class object.
 }
 \details{
 For more details consult
-the \href{https://hubdocs.readthedocs.io/en/latest/format/hub-metadata.html#hub-model-task-metadata-tasks-json-file}{documentation on \code{tasks.json} Hub config files}.
+the \href{https://hubdocs.readthedocs.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
 }
 \examples{
 create_target_metadata(

--- a/man/create_target_metadata_item.Rd
+++ b/man/create_target_metadata_item.Rd
@@ -71,7 +71,7 @@ appended to \code{tasks.json} Hub config files.
 }
 \details{
 For more details consult
-the \href{https://hubdocs.readthedocs.io/en/latest/format/hub-metadata.html#hub-model-task-metadata-tasks-json-file}{documentation on \code{tasks.json} Hub config files}.
+the \href{https://hubdocs.readthedocs.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
 }
 \examples{
 create_target_metadata_item(

--- a/man/create_task_id.Rd
+++ b/man/create_task_id.Rd
@@ -46,7 +46,7 @@ appended to \code{tasks.json} Hub config files.
 \details{
 \code{required} and \code{optional} vectors for standard task_ids defined in a Hub schema
 must match data types and formats specified in the schema. For more details consult
-the \href{https://hubdocs.readthedocs.io/en/latest/format/hub-metadata.html#hub-model-task-metadata-tasks-json-file}{documentation on \code{tasks.json} Hub config files}
+the \href{https://hubdocs.readthedocs.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}
 
 JSON schema data type names differ to those in R. Use the following mappings to
 create vectors of appropriate data types which will correspond to correct JSON

--- a/man/create_task_id.Rd
+++ b/man/create_task_id.Rd
@@ -60,7 +60,7 @@ schema data types during config file validation.\tabular{ll}{
 
 
 Values across \code{required} and \code{optional} arguments must be unique. \code{required}
-and \code{optional} must be of the same type (unless \code{NULL}) and both cannot be \code{NULL}.
+and \code{optional} must be of the same type (unless \code{NULL}).
 Task_ids that represent dates must be supplied as character strings in ISO 8601
 date format (YYYY-MM-DD). If working with date objects, please convert to character
 (e.g. using \code{as.character()}) before supplying as arguments.

--- a/man/create_task_ids.Rd
+++ b/man/create_task_ids.Rd
@@ -17,7 +17,7 @@ Create a \code{task_ids} class object.
 }
 \details{
 For more details consult
-the \href{https://hubdocs.readthedocs.io/en/latest/format/hub-metadata.html#hub-model-task-metadata-tasks-json-file}{documentation on \code{tasks.json} Hub config files}.
+the \href{https://hubdocs.readthedocs.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
 }
 \examples{
 create_task_ids(

--- a/tests/testthat/_snaps/create_task_id.md
+++ b/tests/testthat/_snaps/create_task_id.md
@@ -72,15 +72,25 @@
       attr(,"schema_id")
       [1] "https://raw.githubusercontent.com/Infectious-Disease-Modeling-Hubs/schemas/main/v2.0.1/tasks-schema.json"
 
-# create_task_id errors correctly
+---
 
     Code
       create_task_id("horizon", required = NULL, optional = NULL)
-    Condition
-      Error in `check_prop_not_all_null()`:
-      x Both arguments `required` and `optional` cannot be NULL.
+    Output
+      $horizon
+      $horizon$required
+      NULL
+      
+      $horizon$optional
+      NULL
+      
+      
+      attr(,"class")
+      [1] "task_id" "list"   
+      attr(,"schema_id")
+      [1] "https://raw.githubusercontent.com/Infectious-Disease-Modeling-Hubs/schemas/main/v2.0.1/tasks-schema.json"
 
----
+# create_task_id errors correctly
 
     Code
       create_task_id("origin_date", required = NULL, optional = c("01/20/2023"))

--- a/tests/testthat/test-create_task_id.R
+++ b/tests/testthat/test-create_task_id.R
@@ -26,18 +26,16 @@ test_that("create_task_id works correctly", {
       2L
     )
   ))
-})
-
-
-test_that("create_task_id errors correctly", {
   expect_snapshot(
     create_task_id("horizon",
       required = NULL,
       optional = NULL
-    ),
-    error = TRUE
+    )
   )
+})
 
+
+test_that("create_task_id errors correctly", {
   expect_snapshot(
     create_task_id("origin_date",
       required = NULL,


### PR DESCRIPTION
This PR allows task ID `create_task_id()` arguments `required` and `optional` to both be set to `NULL`, facilitating the encoding of `NA` task IDs in modeling tasks where no value is expected for a given task ID.  

Also fixes broken links

Resolves issues:

- [x] #4 
- [x] #10 
- [x] #12 